### PR TITLE
Implement libtcod font format

### DIFF
--- a/colours.go
+++ b/colours.go
@@ -1,0 +1,8 @@
+package main
+
+import "github.com/gen2brain/raylib-go/raylib"
+
+var (
+	Maroon = rl.NewColor(58, 13, 38, 255)
+	Yellow = rl.NewColor(230, 183, 65, 255)
+)

--- a/engine.go
+++ b/engine.go
@@ -34,6 +34,7 @@ func newEngine() *Engine {
 	engine := &Engine{
 		states:  NewStack(),
 		sprites: newSpriteSheet(rl.LoadTexture("arial10x10.png"), 10, 10),
+		font:    newFont("arial10x10.png", 10, 10),
 	}
 
 	engine.PushState(NewLobbyState(engine))

--- a/font.go
+++ b/font.go
@@ -186,3 +186,7 @@ func (f Font) Debug() {
 		fmt.Println("ASCII [", i, "] to idx [", f.asciiMap[i], "]")
 	}
 }
+
+func (f Font) Draw(ord int, position rl.Vector2, tint rl.Color) {
+	rl.DrawTextureRec(f.sprites.TxTiles, f.sprites.AtIdx(ord).r, position, tint)
+}

--- a/font.go
+++ b/font.go
@@ -166,8 +166,7 @@ func (f *Font) decode() {
 }
 
 func (f *Font) mapAsciiToFont(asciiCode, fontCharX, fontCharY int) {
-	tileId := fontCharX + fontCharY*f.sprites.Cols
-	f.asciiMap[asciiCode] = tileId
+	f.asciiMap[asciiCode] = f.sprites.IdxAt(fontCharX, fontCharY)
 }
 
 func (f *Font) mapClone(newCodepoint, oldCodepoint int) {
@@ -187,6 +186,10 @@ func (f Font) Debug() {
 	}
 }
 
-func (f Font) Draw(ord int, position rl.Vector2, tint rl.Color) {
-	rl.DrawTextureRec(f.sprites.TxTiles, f.sprites.AtIdx(ord).r, position, tint)
+func (f Font) Draw(asciiCode int, position rl.Vector2, tint rl.Color) {
+	if asciiCode < 0 || asciiCode > 256 {
+		asciiCode = 0
+	}
+
+	rl.DrawTextureRec(f.sprites.TxTiles, f.sprites.AtIdx(f.asciiMap[asciiCode]).r, position, tint)
 }

--- a/font.go
+++ b/font.go
@@ -146,7 +146,7 @@ func newFont(filename string, w, h int) *Font {
 	}
 
 	font.decode()
-	font.Debug()
+	// font.Debug()
 	return font
 }
 

--- a/font.go
+++ b/font.go
@@ -5,6 +5,7 @@ import (
 	rl "github.com/gen2brain/raylib-go/raylib"
 )
 
+//noinspection GoSnakeCaseUsage,GoUnusedConst
 const (
 	/* single walls */
 	TCOD_CHAR_HLINE = 196
@@ -105,6 +106,7 @@ const (
 // Copyright © 2008-2019, Jice and the libtcod contributors. All rights reserved.
 //
 
+//noinspection GoSnakeCaseUsage
 type tcod_codec_ [256]int
 
 func getTcodCodec() *tcod_codec_ {

--- a/font.go
+++ b/font.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	rl "github.com/gen2brain/raylib-go/raylib"
+)
+
+type tcod_codec_ [256]int
+
+func getTcodCodec() *tcod_codec_ {
+	return &tcod_codec_{
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 76, 77, 0, 0, 0, 0, 0, /* 0 to 15 */
+		71, 70, 72, 0, 0, 0, 0, 0, 64, 65, 67, 66, 0, 73, 68, 69, /* 16 to 31 */
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, /* 32 to 47 */
+		16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, /* 48 to 63 */
+		32, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, /* 64 to 79 */
+		111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 33, 34, 35, 36, 37, /* 80 to 95 */
+		38, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, /* 96 to 111 */
+		143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 39, 40, 41, 42, 0, /* 112 to 127 */
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 128 to 143 */
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 144 to 159 */
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 160 to 175 */
+		43, 44, 45, 46, 49, 0, 0, 0, 0, 81, 78, 87, 88, 0, 0, 55, /* 176 to 191 */
+		53, 50, 52, 51, 47, 48, 0, 0, 85, 86, 82, 84, 83, 79, 80, 0, /* 192 to 207 */
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 56, 54, 0, 0, 0, 0, 0, /* 208 to 223 */
+		74, 75, 57, 58, 59, 60, 61, 62, 63, 0, 0, 0, 0, 0, 0, 0, /* 224 to 239 */
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 240 to 255 */
+	}
+}
+
+//
+// Note: I am only implementing the TCOD Codec here, someone else can fork and
+//       implement other formats if they need them :)
+//
+type Font struct {
+	sprites  *TileSheet
+	asciiMap map[int]int
+}
+
+func newFont(filename string, w, h int) *Font {
+	font := &Font{
+		sprites:  newSpriteSheet(rl.LoadTexture(filename), w, h),
+		asciiMap: make(map[int]int),
+	}
+
+	font.decode()
+	return font
+}
+
+func (f *Font) decode() {
+	codec := getTcodCodec()
+
+	for i := 0; i < 256; i++ {
+		f.mapAsciiToFont(i, codec[i], 0)
+	}
+}
+
+func (f *Font) mapAsciiToFont(asciiCode, fontCharX, fontCharY int) {
+	tileId := fontCharX + fontCharY*f.sprites.Cols
+	f.asciiMap[asciiCode] = tileId
+}
+
+//
+// Output the mapping for checking
+//
+func (f Font) Debug() {
+	for i := 0; i < 256; i++ {
+		fmt.Println("ASCII [", i, "] to idx [", f.asciiMap[i], "]")
+	}
+}

--- a/font.go
+++ b/font.go
@@ -5,6 +5,13 @@ import (
 	rl "github.com/gen2brain/raylib-go/raylib"
 )
 
+//
+// The tcod_codec_ comes from https://github.com/libtcod/libtcod/blob/master/src/libtcod/sys_sdl_c.cpp#L165
+// It is the codec for TCOD_FONT_LAYOUT_TCOD and converts from EASCII code-point -> raw tile position.
+// BSD 3-Clause License
+// Copyright © 2008-2019, Jice and the libtcod contributors. All rights reserved.
+//
+
 type tcod_codec_ [256]int
 
 func getTcodCodec() *tcod_codec_ {

--- a/lobby_state.go
+++ b/lobby_state.go
@@ -17,7 +17,7 @@ func NewLobbyState(g *Engine) *LobbyState {
 }
 
 func (s LobbyState) Draw(dt float32) {
-	// ...
+	rl.ClearBackground(Maroon)
 }
 
 func (s *LobbyState) Update(dt float32) {

--- a/main.go
+++ b/main.go
@@ -38,11 +38,9 @@ func main() {
 		//----------------------------------------------------------------------------------
 
 		rl.BeginDrawing()
-		rl.ClearBackground(rl.RayWhite)
-
 		state.Draw(frameTime)
 
-		rl.DrawText(fmt.Sprintf("State: %s | FPS %f | Frame Time: %f", state.GetName(), rl.GetFPS(), frameTime), 20, 20, 10, rl.Black)
+		rl.DrawText(fmt.Sprintf("State: %s | FPS %f | Frame Time: %f", state.GetName(), rl.GetFPS(), frameTime), 20, 20, 10, Yellow)
 		rl.EndDrawing()
 	}
 

--- a/main.go
+++ b/main.go
@@ -28,9 +28,9 @@ func main() {
 		// Update
 		//----------------------------------------------------------------------------------
 
-		if rl.IsKeyPressed(rl.KeyF) {
-			rl.ToggleFullscreen()
-		}
+		//if rl.IsKeyPressed(rl.KeyF) {
+		//	rl.ToggleFullscreen()
+		//}
 
 		state.Update(frameTime)
 

--- a/main_state.go
+++ b/main_state.go
@@ -1,21 +1,21 @@
 package main
 
-import rl "github.com/gen2brain/raylib-go/raylib"
+import (
+	"fmt"
+	rl "github.com/gen2brain/raylib-go/raylib"
+)
 
 type MainState struct {
-	x, y int
+	lastKeyCode, x, y int
 	State
 }
 
-const (
-	spriteSize = 48
-)
-
 func NewMainState(g *Engine) *MainState {
 	s := &MainState{
-		State: State{g},
-		x:     0,
-		y:     0,
+		State:       State{g},
+		x:           0,
+		y:           0,
+		lastKeyCode: 0,
 	}
 
 	return s
@@ -31,23 +31,16 @@ func (s MainState) Draw(dt float32) {
 		}
 	}
 
-	s.g.sprites.At(s.x, s.y).Draw(rl.NewVector2(10, 200), rl.Green)
-
+	s.g.font.Draw(s.lastKeyCode, rl.NewVector2(10, 200), rl.Green)
 }
 
 func (s *MainState) Update(dt float32) {
-	if rl.IsKeyPressed(rl.KeySpace) {
-		s.g.ChangeState(NewLobbyState(s.g))
-	} else if rl.IsKeyPressed(rl.KeyUp) {
-		s.x++
-		if s.x > s.g.sprites.Cols {
-			s.x = 0
-			s.y++
+	keyCode := int(rl.GetKeyPressed())
+	if keyCode > -1 {
+		if keyCode != s.lastKeyCode {
+			fmt.Println(keyCode)
 		}
-		if s.y > s.g.sprites.Rows {
-			s.x = 0
-			s.y = 0
-		}
+		s.lastKeyCode = keyCode
 	}
 }
 

--- a/main_state.go
+++ b/main_state.go
@@ -22,16 +22,16 @@ func NewMainState(g *Engine) *MainState {
 }
 
 func (s MainState) Draw(dt float32) {
-	rl.ClearBackground(rl.Yellow)
+	rl.ClearBackground(Maroon)
 
 	// test sprite sheet whole
 	for y := 0; y < s.g.sprites.Rows; y++ {
 		for x := 0; x < s.g.sprites.Cols; x++ {
-			s.g.sprites.At(x, y).Draw(rl.NewVector2(float32(10+(10*x)), float32(50+(10*y))), rl.Green)
+			s.g.sprites.At(x, y).Draw(rl.NewVector2(float32(10+(10*x)), float32(50+(10*y))), Yellow)
 		}
 	}
 
-	s.g.font.Draw(s.lastKeyCode, rl.NewVector2(10, 200), rl.Green)
+	s.g.font.Draw(s.lastKeyCode, rl.NewVector2(10, 200), Yellow)
 }
 
 func (s *MainState) Update(dt float32) {

--- a/tilesheet.go
+++ b/tilesheet.go
@@ -59,6 +59,7 @@ func (t TileSheet) At(x, y int) *Tile {
 }
 
 func (t TileSheet) AtIdx(idx int) *Tile {
+	// @todo add bounds check
 	return t.Tiles[idx]
 }
 


### PR DESCRIPTION
This PR implements the libtcod TCOD fontfile format/codec. I have ported just what is needed for the TCOD implementation other codecs can be added in future if required. Or the whole lot can be factored out into its own lib.

Closes #1